### PR TITLE
feat: Store, API 구현

### DIFF
--- a/src/lib/api/board.ts
+++ b/src/lib/api/board.ts
@@ -1,0 +1,40 @@
+import request from '@lib/api/request';
+import { BoardColumnType, BoardItemType, BoardParamsType } from '@lib/type/board.type';
+
+export const apiGetBoardList = async () => {
+  const response = await request.get<BoardColumnType[]>('/boards');
+  return response;
+};
+
+export const apiDeleteBoardColumn = async (boardId: string) => {
+  await request.delete(`/boards/${boardId}`);
+};
+
+export const apiPostBoard = async ({ boardId, title }: Pick<BoardParamsType, 'boardId' | 'title'>) => {
+  const response = await request.post<BoardItemType>('/board', { boardId, title });
+  return response;
+};
+
+export const apiPutMoveBoard = async ({ boardId, itemId, targetIndex }: Pick<BoardParamsType, 'boardId' | 'itemId' | 'targetIndex'>) => {
+  const response = await request.put<BoardColumnType[]>('/board/move', { boardId, itemId, targetIndex });
+  return response;
+};
+
+export const apiDeleteBoardItem = async ({ boardId, itemId }: Pick<BoardParamsType, 'boardId' | 'itemId'>) => {
+  await request.delete(`/board/${boardId}/${itemId}`);
+};
+
+export const apiPatchBoardItem = async ({ boardId, itemId, title }: Pick<BoardParamsType, 'boardId' | 'itemId' | 'title'>) => {
+  const response = await request.patch<BoardItemType>(`/board/${boardId}/${itemId}`, { title });
+  return response;
+};
+
+export const apiPatchBoardColumn = async ({ boardId, title }: Pick<BoardParamsType, 'boardId' | 'title'>) => {
+  const response = await request.patch<BoardColumnType>(`/board/${boardId}`, { title });
+  return response;
+};
+
+export const apiPostBoardColumn = async ({ title }: Pick<BoardParamsType, 'title'>) => {
+  const response = await request.post<BoardColumnType>(`/boards`, { title });
+  return response;
+};

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,1 +1,4 @@
 export { default as useConnectedMSW } from './useConnectedMSW';
+export { default as useDragAndDrop } from './useDragAndDrop';
+export { default as useEffectOnce } from './useEffectOnce';
+export { default as useUpdateInitialBoard } from './useUpdateInitialBoard';

--- a/src/lib/hooks/useEffectOnce.tsx
+++ b/src/lib/hooks/useEffectOnce.tsx
@@ -1,0 +1,7 @@
+import { EffectCallback, useEffect } from 'react';
+
+const useEffectOnce = (effect: EffectCallback) => {
+  useEffect(effect, []);
+};
+
+export default useEffectOnce;

--- a/src/lib/hooks/useUpdateInitialBoard.tsx
+++ b/src/lib/hooks/useUpdateInitialBoard.tsx
@@ -1,10 +1,10 @@
 import { apiGetBoardList } from '@lib/api/board';
 import { setInitialBoardAction } from '@lib/store/reducer/boardReducer';
-import UseStore from '@lib/store/useStore';
+import useStore from '@lib/store/useStore';
 import { useEffectOnce } from '@lib/hooks';
 
 const useUpdateInitialBoard = () => {
-  const { dispatch } = UseStore();
+  const { dispatch } = useStore();
 
   const updateInitialBoard = async () => {
     const boards = await apiGetBoardList();

--- a/src/lib/hooks/useUpdateInitialBoard.tsx
+++ b/src/lib/hooks/useUpdateInitialBoard.tsx
@@ -1,0 +1,19 @@
+import { apiGetBoardList } from '@lib/api/board';
+import { setInitialBoardAction } from '@lib/store/reducer/boardReducer';
+import UseStore from '@lib/store/useStore';
+import { useEffectOnce } from '@lib/hooks';
+
+const useUpdateInitialBoard = () => {
+  const { dispatch } = UseStore();
+
+  const updateInitialBoard = async () => {
+    const boards = await apiGetBoardList();
+    dispatch(setInitialBoardAction(boards));
+  };
+
+  useEffectOnce(() => {
+    updateInitialBoard();
+  });
+};
+
+export default useUpdateInitialBoard;

--- a/src/lib/msw/MockStore.ts
+++ b/src/lib/msw/MockStore.ts
@@ -1,19 +1,106 @@
-import { BoardList, IMockStore } from '@lib/type/msw.type';
+import { v4 as uuidv4 } from 'uuid';
+
+import { IMockStore } from '@lib/type/msw.type';
+import { BoardColumnType, BoardItemType, BoardParamsType } from '@lib/type/board.type';
+import { insertBoardItem, removeBoardItem, updateBoardColumnTitleById, updateBoardItemTitleById } from '@lib/utils/board';
+
+type GetTemplateBoardColumn = (title?: string) => BoardColumnType;
+type GetTemplateBoardColumnWithItems = (title?: string) => BoardColumnType;
+type GetTemplateBoardItem = (title?: string) => BoardItemType;
+
+const getTemplateBoardColumn: GetTemplateBoardColumn = (title: string = '') => ({
+  boardId: uuidv4(),
+  title,
+  items: [],
+});
+
+const getTemplateBoardColumnWithItems: GetTemplateBoardColumnWithItems = (title = '') => ({
+  boardId: uuidv4(),
+  title,
+  items: [getTemplateBoardItem(`${title} - 1`), getTemplateBoardItem(`${title} - 2`), getTemplateBoardItem(`${title} - 3`), getTemplateBoardItem(`${title} - 4`)],
+});
+
+const getTemplateBoardItem: GetTemplateBoardItem = (title = '') => ({
+  itemId: uuidv4(),
+  title,
+  author: 'bytrustu',
+});
 
 class MockStore implements IMockStore {
-  boards: BoardList;
+  boards: BoardColumnType[];
 
   constructor() {
-    this.boards = [];
+    this.boards = [getTemplateBoardColumnWithItems('할 일'), getTemplateBoardColumnWithItems('진행 중'), getTemplateBoardColumnWithItems('완료')];
   }
 
   getBoards() {
     return this.boards;
   }
 
-  addBoard(board: string) {
+  getBoardById(boardId: string) {
+    return this.boards.find((data) => data.boardId === boardId);
+  }
+
+  getBoardItemById({ boardId, itemId }: Pick<BoardParamsType, 'boardId' | 'itemId'>) {
+    const board = this.getBoardById(boardId);
+    if (!board) {
+      return null;
+    }
+    const item = board.items.find((item) => item.itemId === itemId);
+    if (!item) {
+      return null;
+    }
+    return item;
+  }
+
+  getBoardLastItemById(boardId: string) {
+    const board = this.getBoardById(boardId);
+    if (!board) {
+      return null;
+    }
+    return board.items[board.items.length - 1];
+  }
+
+  addBoardById({ boardId, title }: Pick<BoardParamsType, 'boardId' | 'title'>) {
+    const boardIndex = this.boards.findIndex((data) => data.boardId === boardId);
+    if (boardIndex !== -1) {
+      const board = getTemplateBoardItem(title);
+      this.boards[boardIndex].items.push(board);
+    }
+  }
+
+  moveBoardItem({ boardId, itemId, targetIndex }: Pick<BoardParamsType, 'boardId' | 'itemId' | 'targetIndex'>) {
+    const findBoardItem = [...this.boards.map((board) => board.items).flat()].find((item) => item.itemId === itemId);
+    if (!findBoardItem) {
+      return;
+    }
+    const boardsWithoutItem = removeBoardItem(this.boards, itemId);
+    this.boards = insertBoardItem(boardsWithoutItem, boardId, findBoardItem, targetIndex);
+  }
+
+  removeBoardColumnById(boardId: string) {
+    this.boards = this.boards.filter((data) => data.boardId !== boardId);
+  }
+
+  removeBoardItemById({ boardId, itemId }: Pick<BoardParamsType, 'boardId' | 'itemId'>) {
+    const boardIndex = this.boards.findIndex((data) => data.boardId === boardId);
+    if (boardIndex !== -1) {
+      this.boards[boardIndex].items = this.boards[boardIndex].items.filter((item) => item.itemId !== itemId);
+    }
+  }
+
+  updateBoardItemById({ boardId, itemId, title }: Pick<BoardParamsType, 'boardId' | 'itemId' | 'title'>) {
+    this.boards = updateBoardItemTitleById(this.boards, boardId, itemId, title);
+  }
+
+  updateBoardColumnById({ boardId, title }: Pick<BoardParamsType, 'boardId' | 'title'>) {
+    this.boards = updateBoardColumnTitleById(this.boards, boardId, title);
+  }
+
+  addBoardColumn(title: string) {
+    const board = getTemplateBoardColumn(title);
     this.boards.push(board);
-    return this.getBoards();
+    return board;
   }
 }
 

--- a/src/lib/msw/api.ts
+++ b/src/lib/msw/api.ts
@@ -3,6 +3,7 @@ import { rest } from 'msw';
 import MockStore from '@lib/msw/MockStore';
 import { MockServer } from '@lib/type/msw.type';
 import { isObjectEmpty } from '@lib/utils/object';
+import { BoardParamsType } from '@lib/type/board.type';
 
 const mockServer: MockServer = ({ method, path, statusCode, responseCallback }) =>
   rest[method](path, (req, res, ctx) => {
@@ -20,7 +21,90 @@ export const mockGetBoards = () =>
     method: 'get',
     path: '/api/boards',
     statusCode: 200,
-    responseCallback: () => MockStore.addBoard('이슈 트래커 리액트'),
+    responseCallback: () => MockStore.getBoards(),
   });
 
-export default [mockGetBoards];
+export const mockPostBoard = () =>
+  mockServer({
+    method: 'post',
+    path: '/api/board',
+    statusCode: 200,
+    responseCallback: ({ data }) => {
+      const { boardId, title } = data as Pick<BoardParamsType, 'boardId' | 'title'>;
+      MockStore.addBoardById({ boardId, title });
+      return MockStore.getBoardLastItemById(boardId);
+    },
+  });
+
+export const mockPutMoveBoard = () =>
+  mockServer({
+    method: 'put',
+    path: '/api/board/move',
+    statusCode: 200,
+    responseCallback: ({ data }) => {
+      const { boardId, itemId, targetIndex } = data as Pick<BoardParamsType, 'boardId' | 'itemId' | 'targetIndex'>;
+      MockStore.moveBoardItem({ boardId, itemId, targetIndex });
+      return MockStore.getBoards();
+    },
+  });
+
+export const mockDeleteBoardColumn = () =>
+  mockServer({
+    method: 'delete',
+    path: '/api/boards/:boardId',
+    statusCode: 200,
+    responseCallback: ({ params }) => {
+      const { boardId } = params as Pick<BoardParamsType, 'boardId'>;
+      MockStore.removeBoardColumnById(boardId);
+    },
+  });
+
+export const mockDeleteBoardItem = () =>
+  mockServer({
+    method: 'delete',
+    path: '/api/board/:boardId/:itemId',
+    statusCode: 200,
+    responseCallback: ({ params }) => {
+      const { boardId, itemId } = params as Pick<BoardParamsType, 'boardId' | 'itemId'>;
+      MockStore.removeBoardItemById({ boardId, itemId });
+    },
+  });
+
+export const mockPatchBoardItem = () =>
+  mockServer({
+    method: 'patch',
+    path: '/api/board/:boardId/:itemId',
+    statusCode: 200,
+    responseCallback: ({ params, data }) => {
+      const { boardId, itemId } = params as Pick<BoardParamsType, 'boardId' | 'itemId'>;
+      const { title } = data as Pick<BoardParamsType, 'title'>;
+      MockStore.updateBoardItemById({ boardId, itemId, title });
+      return MockStore.getBoardItemById({ boardId, itemId });
+    },
+  });
+
+export const mockPatchBoardColumn = () =>
+  mockServer({
+    method: 'patch',
+    path: '/api/board/:boardId',
+    statusCode: 200,
+    responseCallback: ({ params, data }) => {
+      const { boardId } = params as Pick<BoardParamsType, 'boardId'>;
+      const { title } = data as Pick<BoardParamsType, 'title'>;
+      MockStore.updateBoardColumnById({ boardId, title });
+      return MockStore.getBoardById(boardId)?.title;
+    },
+  });
+
+export const mockPostBoardColumn = () =>
+  mockServer({
+    method: 'post',
+    path: '/api/boards',
+    statusCode: 200,
+    responseCallback: ({ data }) => {
+      const { title } = data as Pick<BoardParamsType, 'title'>;
+      return MockStore.addBoardColumn(title);
+    },
+  });
+
+export default [mockGetBoards, mockPostBoard, mockPutMoveBoard, mockDeleteBoardColumn, mockDeleteBoardItem, mockPatchBoardItem, mockPatchBoardColumn, mockPostBoardColumn];

--- a/src/lib/store/config/baseStore.ts
+++ b/src/lib/store/config/baseStore.ts
@@ -1,0 +1,31 @@
+import Observer from './observer';
+
+type Reducer<State, Action> = (state: State, action: Action) => State;
+
+type StoreOptions<State, Action> = {
+  reducer: Reducer<State, Action>;
+  initialState?: State;
+};
+
+class BaseStore<State, Action> extends Observer {
+  private state: State;
+
+  private readonly reducer: Reducer<State, Action>;
+
+  constructor(options: StoreOptions<State, Action>) {
+    super();
+    this.state = options.initialState ?? ({} as State);
+    this.reducer = options.reducer;
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  dispatch(action: Action) {
+    this.state = this.reducer(this.state, action);
+    this.notify();
+  }
+}
+
+export default BaseStore;

--- a/src/lib/store/config/index.ts
+++ b/src/lib/store/config/index.ts
@@ -1,0 +1,6 @@
+import BaseStore from '@lib/store/config/baseStore';
+import reducer, { initialState } from '@lib/store/reducer/boardReducer';
+
+const store = new BaseStore({ reducer, initialState });
+
+export default store;

--- a/src/lib/store/config/observer.ts
+++ b/src/lib/store/config/observer.ts
@@ -1,0 +1,20 @@
+type Listener = () => void;
+
+class Observer {
+  private listeners: Set<Listener> = new Set();
+
+  public subscribe(listener: Listener) {
+    this.listeners.add(listener);
+    return () => this.unsubscribe(listener);
+  }
+
+  public unsubscribe(listener: Listener) {
+    this.listeners.delete(listener);
+  }
+
+  public notify() {
+    this.listeners.forEach((listener) => listener());
+  }
+}
+
+export default Observer;

--- a/src/lib/store/reducer/boardReducer.ts
+++ b/src/lib/store/reducer/boardReducer.ts
@@ -1,0 +1,151 @@
+import { BoardColumnType, BoardItemType } from '@lib/type/board.type';
+import { insertBoardItem, removeBoardItem, updateBoardColumnTitleById, updateBoardItemTitleById } from '@lib/utils/board';
+
+export const SET_INITIAL_BOARD_ACTION = 'BOARD/SET_INITIAL' as const;
+export const ADD_BOARD_ITEM_ACTION = 'BOARD/ADD_ITEM' as const;
+export const REMOVE_BOARD_ITEM_ACTION = 'BOARD/REMOVE_ITEM' as const;
+export const EDIT_BOARD_ITEM_ACTION = 'BOARD/EDIT_ITEM' as const;
+export const ADD_BOARD_COLUMN_ACTION = 'BOARD/ADD_COLUMN' as const;
+export const EDIT_BOARD_COLUMN_ACTION = 'BOARD/EDIT_COLUMN' as const;
+export const MOVE_BOARD_ITEM_ACTION = 'BOARD/MOVE_ITEM' as const;
+export const REMOVE_BOARD_COLUMN_ACTION = 'BOARD/REMOVE_COLUMN' as const;
+
+export const setInitialBoardAction = (payload: BoardColumnType[]) => ({
+  type: SET_INITIAL_BOARD_ACTION,
+  payload,
+});
+
+export const addBoardItemAction = (payload: { boardId: string; item: BoardItemType }) => ({
+  type: ADD_BOARD_ITEM_ACTION,
+  payload,
+});
+
+export const removeBoardItemAction = (payload: { boardId: string; itemId: string }) => ({
+  type: REMOVE_BOARD_ITEM_ACTION,
+  payload,
+});
+
+export const editBoardItemAction = (payload: { boardId: string; itemId: string; title: string }) => ({
+  type: EDIT_BOARD_ITEM_ACTION,
+  payload,
+});
+
+export const addBoardColumnAction = (payload: BoardColumnType) => ({
+  type: ADD_BOARD_COLUMN_ACTION,
+  payload,
+});
+
+export const editBoardColumnAction = (payload: { boardId: string; title: string }) => ({
+  type: EDIT_BOARD_COLUMN_ACTION,
+  payload,
+});
+
+export const moveBoardItemAction = (payload: { boardId: string; itemId: string; targetIndex: number }) => ({
+  type: MOVE_BOARD_ITEM_ACTION,
+  payload,
+});
+
+export const removeBoardColumnAction = (payload: string) => ({
+  type: REMOVE_BOARD_COLUMN_ACTION,
+  payload,
+});
+
+export const initialState: BoardState = {
+  boards: [],
+};
+
+type BoardState = {
+  boards: BoardColumnType[];
+};
+
+export type BoardAction = ReturnType<
+  | typeof setInitialBoardAction
+  | typeof addBoardItemAction
+  | typeof removeBoardItemAction
+  | typeof editBoardItemAction
+  | typeof addBoardColumnAction
+  | typeof editBoardColumnAction
+  | typeof moveBoardItemAction
+  | typeof removeBoardColumnAction
+>;
+
+const reducer = (state: BoardState, action: BoardAction) => {
+  switch (action.type) {
+    case SET_INITIAL_BOARD_ACTION:
+      return {
+        ...state,
+        boards: action.payload,
+      };
+    case ADD_BOARD_ITEM_ACTION: {
+      const { boardId, item } = action.payload;
+      return {
+        ...state,
+        boards: state.boards.map((board) => {
+          if (board.boardId === boardId) {
+            return {
+              ...board,
+              items: [...board.items, item],
+            };
+          }
+          return board;
+        }),
+      };
+    }
+    case REMOVE_BOARD_ITEM_ACTION: {
+      const { boardId, itemId } = action.payload;
+      return {
+        ...state,
+        boards: state.boards.map((board) => {
+          if (board.boardId === boardId) {
+            return {
+              ...board,
+              items: board.items.filter((item) => item.itemId !== itemId),
+            };
+          }
+          return board;
+        }),
+      };
+    }
+    case EDIT_BOARD_ITEM_ACTION: {
+      const { boardId, itemId, title } = action.payload;
+      const boards = updateBoardItemTitleById(state.boards, boardId, itemId, title);
+      return {
+        ...state,
+        boards,
+      };
+    }
+    case ADD_BOARD_COLUMN_ACTION:
+      return {
+        ...state,
+        boards: [...state.boards, action.payload],
+      };
+    case EDIT_BOARD_COLUMN_ACTION: {
+      const { boardId, title } = action.payload;
+      return {
+        ...state,
+        boards: updateBoardColumnTitleById(state.boards, boardId, title),
+      };
+    }
+    case MOVE_BOARD_ITEM_ACTION: {
+      const { boardId, itemId, targetIndex } = action.payload;
+      const findBoardItem = state.boards.flatMap((board) => board.items).find((item) => item.itemId === itemId);
+      if (!findBoardItem) {
+        return state;
+      }
+      const boardsWithoutItem = removeBoardItem(state.boards, itemId);
+      return {
+        ...state,
+        boards: insertBoardItem(boardsWithoutItem, boardId, findBoardItem, targetIndex),
+      };
+    }
+    case REMOVE_BOARD_COLUMN_ACTION:
+      return {
+        ...state,
+        boards: state.boards.filter((board) => board.boardId !== action.payload),
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/lib/store/storeUtils.ts
+++ b/src/lib/store/storeUtils.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react';
+import BaseStore from '@lib/store/config/baseStore';
+
+const storeUtils = <State, Action>(store: BaseStore<State, Action>) => {
+  const stateRef = useRef(store.getState());
+  const [, forceRender] = useState({});
+
+  const selector = <SelectedState>(selector: (state: State) => SelectedState): SelectedState => selector(stateRef.current);
+
+  const dispatch = (action: Action) => {
+    store.dispatch(action);
+    stateRef.current = store.getState();
+    forceRender({});
+  };
+
+  useEffect(() => {
+    const unsubscribe = store.subscribe(() => {
+      stateRef.current = store.getState();
+      forceRender({});
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [store]);
+
+  return {
+    selector,
+    dispatch,
+  };
+};
+
+export default storeUtils;

--- a/src/lib/store/storeUtils.ts
+++ b/src/lib/store/storeUtils.ts
@@ -9,8 +9,11 @@ const storeUtils = <State, Action>(store: BaseStore<State, Action>) => {
 
   const dispatch = (action: Action) => {
     store.dispatch(action);
-    stateRef.current = store.getState();
-    forceRender({});
+    const nextState = store.getState();
+    if (stateRef.current !== nextState) {
+      stateRef.current = store.getState();
+      forceRender({});
+    }
   };
 
   useEffect(() => {

--- a/src/lib/store/useStore.ts
+++ b/src/lib/store/useStore.ts
@@ -1,0 +1,12 @@
+import store from '@lib/store/config';
+import storeUtils from '@lib/store/storeUtils';
+
+const useStore = () => {
+  const { selector, dispatch } = storeUtils(store);
+  return {
+    selector,
+    dispatch,
+  };
+};
+
+export default useStore;

--- a/src/lib/type/board.type.ts
+++ b/src/lib/type/board.type.ts
@@ -9,3 +9,10 @@ export type BoardItemType = {
   title: string;
   author: string;
 };
+
+export type BoardParamsType = {
+  boardId: string;
+  title: string;
+  itemId: string;
+  targetIndex: number;
+};

--- a/src/lib/type/msw.type.ts
+++ b/src/lib/type/msw.type.ts
@@ -1,11 +1,12 @@
 import { DefaultBodyType, Path, PathParams, RequestHandler, rest } from 'msw';
+import { BoardColumnType, BoardItemType, BoardParamsType } from '@lib/type/board.type';
 
 type ResponseCallbackParams = {
   params?: PathParams;
   data?: DefaultBodyType;
 };
 
-type ResponseCallback = (params: ResponseCallbackParams) => BoardList;
+type ResponseCallback = (params: ResponseCallbackParams) => any;
 
 type RestMethod = keyof typeof rest;
 
@@ -21,9 +22,16 @@ type MswRestMethod = (path: Path, resolver: RequestHandler) => ReturnType<(typeo
 export type MockServer = (options: MockServerOptions) => ReturnType<MswRestMethod>;
 
 export interface IMockStore {
-  boards: BoardList;
-  getBoards: () => BoardList;
-  addBoard: (board: string) => BoardList;
+  boards: BoardColumnType[];
+  getBoards: () => BoardColumnType[];
+  getBoardById: (boardId: string) => BoardColumnType | undefined;
+  getBoardItemById: ({ boardId, itemId }: Pick<BoardParamsType, 'boardId' | 'itemId'>) => BoardItemType | null;
+  getBoardLastItemById: (boardId: string) => BoardItemType | null;
+  addBoardById: ({ boardId, title }: Pick<BoardParamsType, 'boardId' | 'title'>) => void;
+  moveBoardItem: ({ itemId, boardId, targetIndex }: Pick<BoardParamsType, 'itemId' | 'boardId' | 'targetIndex'>) => void;
+  removeBoardColumnById: (boardId: string) => void;
+  removeBoardItemById: ({ boardId, itemId }: Pick<BoardParamsType, 'boardId' | 'itemId'>) => void;
+  updateBoardItemById: ({ boardId, itemId, title }: Pick<BoardParamsType, 'boardId' | 'itemId' | 'title'>) => void;
+  updateBoardColumnById: ({ boardId, title }: Pick<BoardParamsType, 'boardId' | 'title'>) => void;
+  addBoardColumn: (title: string) => void;
 }
-
-export type BoardList = string[];

--- a/src/lib/utils/board.ts
+++ b/src/lib/utils/board.ts
@@ -1,0 +1,37 @@
+import { BoardColumnType, BoardItemType } from '@lib/type/board.type';
+
+export const removeBoardItem = (boards: BoardColumnType[], itemId: string) =>
+  boards.map((board) => ({
+    ...board,
+    items: board.items.filter((item) => item.itemId !== itemId),
+  }));
+
+export const insertBoardItem = (boards: BoardColumnType[], boardId: string, item: BoardItemType, targetIndex: number) =>
+  boards.map((board) => {
+    if (board.boardId === boardId) {
+      return {
+        ...board,
+        items: [...board.items.slice(0, targetIndex), item, ...board.items.slice(targetIndex)],
+      };
+    }
+    return board;
+  });
+
+export const updateBoardItemTitleById = (boards: BoardColumnType[], boardId: string, itemId: string, title: string) => {
+  const boardIndex = boards.findIndex((data) => data.boardId === boardId);
+  if (boardIndex !== -1) {
+    const boardItemIndex = boards[boardIndex].items.findIndex((item) => item.itemId === itemId);
+    if (boardItemIndex !== -1) {
+      boards[boardIndex].items[boardItemIndex].title = title;
+    }
+  }
+  return boards;
+};
+
+export const updateBoardColumnTitleById = (boards: BoardColumnType[], boardId: string, title: string) => {
+  const boardIndex = boards.findIndex((data) => data.boardId === boardId);
+  if (boardIndex !== -1) {
+    boards[boardIndex].title = title;
+  }
+  return boards;
+};

--- a/src/ui/pages/Main.page.tsx
+++ b/src/ui/pages/Main.page.tsx
@@ -1,24 +1,31 @@
 import { PageHeader, PageLayout, PageBody } from '@ui/components/layout';
 import { Board, BoardColumnCreate } from '@ui/components/board';
 import { DraggableArea } from '@ui/components/common';
-import { boardFixture } from '@lib/fixture/board.fixture';
+import { useUpdateInitialBoard } from '@lib/hooks';
+import useStore from '@lib/store/useStore';
 
-const MainPage = () => (
-  <PageLayout>
-    <PageHeader />
-    <PageBody>
-      <DraggableArea
-        onDrop={(data) => {
-          console.log('drop', data);
-        }}
-      >
-        {boardFixture.map((board) => (
-          <Board key={board.boardId} boardId={board.boardId} title={board.title} items={board.items} />
-        ))}
-      </DraggableArea>
-      <BoardColumnCreate onClick={() => {}} />
-    </PageBody>
-  </PageLayout>
-);
+const MainPage = () => {
+  const { selector } = useStore();
+  const boards = selector((state) => state.boards);
+
+  useUpdateInitialBoard();
+  return (
+    <PageLayout>
+      <PageHeader />
+      <PageBody>
+        <DraggableArea
+          onDrop={(data) => {
+            console.log('drop', data);
+          }}
+        >
+          {boards.map((board) => (
+            <Board key={board.boardId} boardId={board.boardId} title={board.title} items={board.items} />
+          ))}
+        </DraggableArea>
+        <BoardColumnCreate onClick={() => {}} />
+      </PageBody>
+    </PageLayout>
+  );
+};
 
 export default MainPage;


### PR DESCRIPTION
## 작업 주제

- #7 

## 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 스토어 구현
  - baseStore 추가 5df20df3a17606cab6915e04f6c884bbcccf866e
  - useStore 구현 b485d17e6e595d6257ae79beb4b09a0c7a6c961f
    - useStore에서 dispatch, selector를 받아서 활용하도록 구현했습니다.
- Board 리듀서 추가 9ad390a096036aa61ba3cddaa59755a70ecdefbd
- MSW API 추가 db03e6488f9a44ce13c23ed82c556801ec25dbdf
- Axios API 추가 00ef2fb25c86b4df39f28364d99aa2546bcacc91

## 화면 스크린샷

![image](https://user-images.githubusercontent.com/39726717/236670122-0149b08f-d98f-4dcc-a96c-b37f9031e22a.png)

## 추가 코멘트

Store를 구현하면서 [storeUtils](https://github.com/f-lab-edu/issue-tracker-react/blob/2aed38f8f1b4e1b333b60bfad1d56a3ea56496b8/src/lib/store/storeUtils.ts)에서 컴포넌트 렌더링을 처리하였습니다.
`sagen store`를 참고하였는데, `useRef`를 사용하여 Store 값을 저장하고, 강제 렌더링을 위해 `setState`를 활용하는 방식으로 구현되어 있었습니다. 이 부분을 참고해서 구현해보았어요.  
[링크](https://github.com/jungpaeng/sagen-monorepo/blob/cc8783223dd04332771afa786790d93f802d249d/packages/sagen/src/hooks/useObserverStateUpdate.ts#L79)

데이터를 반영하고 바로 강제렌더링을 시키다보니  
useState에 Store 값을 반영하는 것과 차이가 없지 않을까? 싶습니다. 🤔  
이 부분에서 렌더링 시키는 부분을 다른 처리가 있을때 더 유용하게 사용하게 될 것 같다는 생각이 들었어요.

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
